### PR TITLE
Squelching WordPress Debug Mode Warnings

### DIFF
--- a/setup/class.dropdowns_walker.php
+++ b/setup/class.dropdowns_walker.php
@@ -21,7 +21,7 @@ class UW_Dropdowns_Walker_Menu extends Walker_Nav_Menu
 //    return str_replace('class="dawgdrops-nav"', 'class="dawgdrops-nav" role="menubar"', $html);
 //  }
 
-  function start_lvl( &$output, $depth, $args )
+  function start_lvl( &$output, $depth = 0, $args = array() )
   {
     if ( $depth > 0 ) return;
 		$output .= "<ul role=\"group\" id=\"menu-{$this->CURRENT}\" aria-labelledby='{$this->CURRENT}' aria-expanded=\"false\" class=\"dawgdrops-menu\">\n";
@@ -42,7 +42,7 @@ class UW_Dropdowns_Walker_Menu extends Walker_Nav_Menu
       return parent::display_element($element, $children_elements, $max_depth, $depth, $args, $output);
   }
 
-  function start_el(&$output, $item, $depth, $args)
+  function start_el(&$output, $item, $depth = 0, $args = array() , $id=0)
   {
     if ( $depth > 1 )
       return;

--- a/widgets/class.uw-single-image.php
+++ b/widgets/class.uw-single-image.php
@@ -20,7 +20,7 @@ class UW_Widget_Single_Image extends WP_Widget
       add_action('admin_enqueue_scripts', array( __CLASS__, 'scripts') );
   }
 
-  function scripts()
+  public static function scripts()
   {
     wp_enqueue_script( 'single-image',  get_bloginfo('template_directory') . '/assets/admin/js/widgets/uw.single-image-widget.js' );
     wp_enqueue_script( 'jquery-ui-autocomplete' );

--- a/widgets/class.uw-widget-visibility.php
+++ b/widgets/class.uw-widget-visibility.php
@@ -283,7 +283,7 @@ class UW_Widget_Conditions
   //  @return array The modified $widget_area array.
   //
 
-  function sidebars_widgets( $widget_areas )
+  public static function sidebars_widgets( $widget_areas )
   {
     $settings = array();
 
@@ -333,7 +333,7 @@ class UW_Widget_Conditions
   //  @return array Settings to display or bool false to hide.
   //
 
-  function filter_widget( $instance )
+  public static function filter_widget( $instance )
   {
     global $post, $wp_query;
 


### PR DESCRIPTION
Depending on the the users wp_config, they might run their theme development with Wordpress's debug mode set to on.  In this case, the theme will throw strict standards warnings on both site and dashboard.
![image](https://cloud.githubusercontent.com/assets/5032954/5145622/342d3f2c-7159-11e4-8813-31a331290a6d.png)

The method calls I think are easy, and I don't think the argument adjustments would affect your walker either.  Let me know what you think.

Tweaks to fix the theme to work with WP_DEBUG set to on for better troubleshooting.  Explicitly declaring statically called methods as such, and argument definition for the dropdowns walker.
