### PR TITLE
Theme without comments.php is depreciated notice on single posts.

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@
 
   					// If comments are open or we have at least one comment, load up the comment template.
   					if ( comments_open() || get_comments_number() ) {
-  				        comments_template('/comments.php');
+  				        comments_template();
   					}
 
   				endwhile;


### PR DESCRIPTION
 Again with my WP_Debug stuff.  

[WP should be defaulting to /comments.php](link=http://codex.wordpress.org/Function_Reference/comments_template) for the comments_template call.  On unformatted single posts you'll get notices (see below) about needing this file.   

If you want to concretely reference the file, '/comments.php' also fixes this.  Weird.

![image](https://cloud.githubusercontent.com/assets/5032954/5366705/ec648cbc-7faa-11e4-90e8-edc90959f1b4.png)
