### PR TITLE
uw.init.js variable case causing JavaScript error for child theme with customized gruntfile.js

### DIFF
--- a/js/uw.init.js
+++ b/js/uw.init.js
@@ -19,7 +19,7 @@ UW.elements = {
 }
 
 UW.getBaseUrl = function() {
-    if (uw.is_multisite == 1) {
+    if (UW.is_multisite == 1) {
       var site = _.first( _.compact( Backbone.history.location.pathname.split('/') ) )
       return Backbone.history.location.origin + ( site ? '/' + site : '' ) + '/'
     } 


### PR DESCRIPTION
## Description:

To include some custom interactivity, the ORIS child theme has customized the **gruntfle.js** to include both the **js** directory in the parent **uw-2014** theme directory and our own set of scripts. When we run our **gruntfile.js**, the resulting **site.js** and **site.dev.js** files cause an error in Google Chrome, reporting the variable **uw** is undefined. Oddly enough, when we switch from our child theme to the parent theme, this error does not show up.

## Impact:

All JavaScript interactivity is broken as a result of the undefined variable.

## Proposed change

Line 22 of **uw.init.js** has the following conditional:

    if (uw.is_multisite == 1) {

The intent seems to be:

    if (UW.is_multisite == 1) {

I don't see any other instance of lowercase **uw** being defined in the compiled **sites.dev.js** or **site.js**.
