### PR TITLE
Capitalize all words in dawgdrops menu items

### DIFF
--- a/less/uw.dropdowns.less
+++ b/less/uw.dropdowns.less
@@ -57,7 +57,7 @@
 		}
 		li a {
 			font-family: @font-family-headline;
-			text-transform: none;
+			text-transform: capitalize;
 			font-weight: @medium;
 			padding-bottom: 4px;
 			padding-left: 10px;


### PR DESCRIPTION
This is Matt Lambert in ORIS. It looks like most items in the Dawgdrops drop-downs are title-cased (each word begins with capital letter). There are some exceptions. Four of the items in the 'Research' drop-down are not title-cased. There are also two items in the 'Apply' drop-down ("Financial aid" and "Undocumented students") that do not have title capitalization.

If UMAC agrees that all Dawgdrop menu items should be title-cased, this change should accomplish that.
