### PR TITLE
update for Widget constructor for WP_Debug

### DIFF
--- a/widgets/class.uw-blogroll.php
+++ b/widgets/class.uw-blogroll.php
@@ -12,7 +12,7 @@ class UW_Blogroll extends WP_Widget
   function __construct()
   {
 
-    parent::WP_Widget( self::ID , __( self::NAME ), array(
+    parent::__construct( self::ID , __( self::NAME ), array(
       'classname' => self::CLASSNAME,
       'description' => __( self::DESCRIPTION )
     ));

--- a/widgets/class.uw-campus-map.php
+++ b/widgets/class.uw-campus-map.php
@@ -11,7 +11,7 @@ class UW_Campus_Map extends WP_Widget
 
   function __construct()
   {
-		parent::WP_Widget( 'uw-campus-map', __('UW Campus Map'), array(
+		parent::__construct( 'uw-campus-map', __('UW Campus Map'), array(
       'description' => __('Show your building on the UW campus map.'),
       'classname'   => 'uw-widget-campus-map'
     ) );

--- a/widgets/class.uw-cards.php
+++ b/widgets/class.uw-cards.php
@@ -14,7 +14,7 @@ class UW_Widget_Cards extends WP_Widget
 
   function __construct()
   {
-		parent::WP_Widget( $id = 'uw-widget-cards', $name = 'Image Cards', $options = array( 'description' => 'Choose from several styles of cards', 'classname' => 'cards-widget' ) );
+		parent::__construct( $id = 'uw-widget-cards', $name = 'Image Cards', $options = array( 'description' => 'Choose from several styles of cards', 'classname' => 'cards-widget' ) );
 
     if ( is_admin() )
       add_action('admin_enqueue_scripts', array( __CLASS__, 'scripts') );

--- a/widgets/class.uw-contact.php
+++ b/widgets/class.uw-contact.php
@@ -14,7 +14,7 @@ class UW_Widget_Contact extends WP_Widget
 
   function UW_Widget_Contact()
   {
-		parent::WP_Widget( $id = 'contact-list', $name = 'Contact list', $options = array( 'description' => 'Display important contact information', 'classname' => 'contact-widget' ) );
+		parent::__construct( $id = 'contact-list', $name = 'Contact list', $options = array( 'description' => 'Display important contact information', 'classname' => 'contact-widget' ) );
 
     if ( is_admin() )
       add_action('admin_enqueue_scripts', array( __CLASS__, 'scripts') );

--- a/widgets/class.uw-intro.php
+++ b/widgets/class.uw-intro.php
@@ -17,7 +17,7 @@ class UW_Intro_Text extends WP_Widget
 
     add_shortcode( 'intro', array( $this, 'intro_shortcode' ) );
 
-    parent::WP_Widget(
+    parent::__construct(
       $id = self::ID,
       $name = self::TITLE,
       $options = array(

--- a/widgets/class.uw-recent-posts.php
+++ b/widgets/class.uw-recent-posts.php
@@ -17,7 +17,7 @@ class UW_Recent_Posts extends WP_Widget
   // Register the widget
   function __construct()
   {
-    parent::WP_Widget(
+    parent::__construct(
       $id      = self::ID,
       $name    = self::TITLE,
       $options = array(

--- a/widgets/class.uw-related-posts.php
+++ b/widgets/class.uw-related-posts.php
@@ -27,7 +27,7 @@ class UW_Widget_Related_Posts extends WP_Widget
       // Instantiate the Jetpack_RelatedPosts class
       $this->RelatedPosts = Jetpack_RelatedPosts::init(); //get_current_blog_id() , Jetpack_Options::get_option( 'id' ) );
 
-      parent::WP_Widget(
+      parent::__construct(
         $id      = self::ID,
         $name    = self::TITLE,
         $options = array(

--- a/widgets/class.uw-rss.php
+++ b/widgets/class.uw-rss.php
@@ -41,7 +41,7 @@ class UW_RSS extends WP_Widget
 
     add_shortcode( 'rss', array( $this, 'uw_rss_shortcode') );
 
-		parent::WP_Widget(
+		parent::__construct(
       $id      = self::ID,
       $name    = self::NAME,
       $options = array(

--- a/widgets/class.uw-single-image.php
+++ b/widgets/class.uw-single-image.php
@@ -14,7 +14,7 @@ class UW_Widget_Single_Image extends WP_Widget
 
   function UW_Widget_Single_Image()
   {
-		parent::WP_Widget( $id = 'pic-text', $name = 'Single Image', $options = array( 'description' => 'Display an image with some featured text.', 'classname' => 'pic-text-widget' ) );
+		parent::__construct( $id = 'pic-text', $name = 'Single Image', $options = array( 'description' => 'Display an image with some featured text.', 'classname' => 'pic-text-widget' ) );
 
     if ( is_admin() )
       add_action('admin_enqueue_scripts', array( __CLASS__, 'scripts') );

--- a/widgets/class.uw-top-posts.php
+++ b/widgets/class.uw-top-posts.php
@@ -19,7 +19,7 @@ class UW_Top_Posts extends WP_Widget
   // Register the widget
   function __construct()
   {
-    parent::WP_Widget(
+    parent::__construct(
       $id      = self::ID,
       $name    = self::TITLE,
       $options = array(

--- a/widgets/class.uw-twitter.php
+++ b/widgets/class.uw-twitter.php
@@ -38,7 +38,7 @@ class UW_Widget_Twitter extends WP_Widget
 
   function UW_Widget_Twitter()
   {
-    parent::WP_Widget(
+    parent::__construct(
       $id = self::ID,
       $name = self::NAME,
       $options = array(


### PR DESCRIPTION
New Syntax since 4.3.0 for the Widget API. 

If you're doing development with wp_debug set to true this corrects warning messages.

[Codex Link](https://codex.wordpress.org/Widgets_API)
