### PR TITLE
Fixed card-image background to appear behind text

### DIFF
--- a/widgets/class.uw-cards.php
+++ b/widgets/class.uw-cards.php
@@ -119,12 +119,12 @@ class UW_Widget_Cards extends WP_Widget
 
     <?php  echo $before_widget; ?>
       
-      <div class="<?php echo $radio ?>">
-      
-      <div class='card-image' style='background-image:url(<?php 
+      <div class="<?php echo $radio ?>" style='background-image:url(<?php 
         $the_image = $image_attributes = wp_get_attachment_image_src( $image, 'large' ); 
         echo  $the_image[0]; ?>
-      )'></div>
+      )'>
+      
+      <div class='card-image'></div>
 
       <span>
       <h3>


### PR DESCRIPTION
Applied HTML background-style (originally at the div with class "card-image") to sibling div at line 122 to fix bug where text appears behind the image on image style cards. Header text colors still need to be fixed on Enhanced and Boundless cards, they're still gray.