### PR TITLE
Two links to "UW Today" with different URLs

### DIFF
--- a/js/uw.quicklinks.js
+++ b/js/uw.quicklinks.js
@@ -169,7 +169,7 @@ UW.QuickLinks.Collection = Backbone.Collection.extend({
        "classes": ["icon-maps"]
    }, {
        "title": "UW Today",
-       "url": "http:\/\/www.uw.edu\/news",
+       "url": "http:\/\/uw.edu\/news",
        "classes": ["icon-uwtoday"]
    }, {
        "title": "Computing\/IT",


### PR DESCRIPTION
I just changed “www” in front of the link to make it consistent with
the “News and Event” dropdown menu. Grunt was running.