### PR TITLE
Allow child themes to set their own version numbers on CSS Files

### DIFF
--- a/setup/class.uw-styles.php
+++ b/setup/class.uw-styles.php
@@ -34,7 +34,7 @@ class UW_Styles
           'id'      => 'uw-style',
           'url'     => get_bloginfo('stylesheet_url'),
           'deps'    => array('uw-master'),
-          'version' => '3.6',
+          'version' => wp_get_theme()->get('Version'),
           'child'   => true
       ),
 


### PR DESCRIPTION
Tweak allows child themes to set their own version number, and therefore bust their own cache using a method of their choice.

Elegantly breaks down, and defaults to the current WordPress version if it's not set in the Child Theme .css file.

[WordPress Documentation](https://developer.wordpress.org/themes/advanced-topics/child-themes/#3-enqueue-stylesheet)