### PR TITLE
Contact widget fix

### DIFF
--- a/assets/admin/js/widgets/uw.contact-widget.js
+++ b/assets/admin/js/widgets/uw.contact-widget.js
@@ -15,11 +15,10 @@ jQuery(document).ready(function( $ ) {
 
   })
 
-
+  // removes a contact and automatically saves the change 
   $('body').on('click', '#sidebar .remove', function(event) {
-
-	var $this = $(this)
-        $this.closest('.peep').remove()
+        this.closest('.peep').remove();
+        $("#widget-contact-list-2-savewidget").trigger('click');
  	})
 
 

--- a/assets/admin/js/widgets/uw.contact-widget.js
+++ b/assets/admin/js/widgets/uw.contact-widget.js
@@ -8,8 +8,8 @@ jQuery(document).ready(function( $ ) {
     var $number = $id.split("_contact-list-").pop();
 
     $(this).parent().find('.uw-contact-card-contact-group').append(
-      _.template( $('#sidebar #redirect-template').html(), { number : $number })
-    )
+      _.template( $('#sidebar #redirect-template').html() ) ( { number : $number } )
+    );
 
 
 
@@ -24,5 +24,3 @@ jQuery(document).ready(function( $ ) {
 
 
 })
-
-

--- a/widgets/class.uw-contact.php
+++ b/widgets/class.uw-contact.php
@@ -35,7 +35,7 @@ class UW_Widget_Contact extends WP_Widget
     //$person_title = isset($instance['person_title']) ? esc_attr($instance['person_title']) : 'Title';
     //$person_phone = isset($instance['person_phone']) ? esc_attr($instance['person_phone']) : 'Telephone number';
     //$person_email = isset($instance['person_email']) ? esc_attr($instance['person_email']) : 'Email';
-    
+
 
     ?>
 
@@ -52,7 +52,7 @@ class UW_Widget_Contact extends WP_Widget
 
 
   <div id="the-people" class="uw-contact-card-the-people">
-  
+
     <?php
 
     if (isset($instance['person_name'])) {
@@ -61,7 +61,7 @@ class UW_Widget_Contact extends WP_Widget
 
       if(is_array($remake_form_person)){
 
-        foreach ($remake_form_person as $key => $values) {       
+        foreach ($remake_form_person as $key => $values) {
 
             $name = $instance['person_name'][$key];
             $title = $instance['person_title'][$key];
@@ -87,7 +87,7 @@ class UW_Widget_Contact extends WP_Widget
             echo '<p class=\'person-email\'><input data-posttype="post" class="widefat wp-get-posts" id="" name="' . $this->get_field_name( 'person_email' ) . '[]' . '" type="text" value="' . $email . '"/></p><a class=\'remove uw-contact-card-remove button\'>Remove</a></div>';
 
       }
-     } 
+     }
 
     ?>
 
@@ -95,18 +95,18 @@ class UW_Widget_Contact extends WP_Widget
 
     <a class="button button-primary uw-contact-card-add-person-button" href="#" id="person-button">Add person</a>
 
-    
+
     <!--||||||||||||||| Underscore template |||||||||||||||-->
 
     <script type="text/template" id="redirect-template" class="uw-contact-card-redirect-template">
-        <?php 
-          $this->number = '<%- number %>'; 
+        <?php
+          $this->number = '<%- number %>';
         ?>
         <div class='peep'>
-          <p><input class="widefat wp-get-posts" data-posttype="post" name="<?php echo $this->get_field_name( 'person_name][' ); ?>" type="text"  placeholder="Name"/></p>
-          <p><input class="widefat wp-get-posts" data-posttype="post" name="<?php echo $this->get_field_name( 'person_title][' ); ?>" type="text"  placeholder="Title"/></p>          
-          <p><input class="widefat wp-get-posts" data-posttype="post" name="<?php echo $this->get_field_name( 'person_phone][' ); ?>" type="text"  placeholder="Phone number"/></p>
-          <p><input class="widefat wp-get-posts" data-posttype="post" name="<?php echo $this->get_field_name( 'person_email][' ); ?>" type="text"  placeholder="Email"/></p>
+          <p><input class="widefat wp-get-posts" data-posttype="post" name="<?php echo $this->get_field_name( 'person_name' ) . '[]'; ?>" type="text"  placeholder="Name"/></p>
+          <p><input class="widefat wp-get-posts" data-posttype="post" name="<?php echo $this->get_field_name( 'person_title' ) . '[]'; ?>" type="text"  placeholder="Title"/></p>
+          <p><input class="widefat wp-get-posts" data-posttype="post" name="<?php echo $this->get_field_name( 'person_phone' ) . '[]'; ?>" type="text"  placeholder="Phone number"/></p>
+          <p><input class="widefat wp-get-posts" data-posttype="post" name="<?php echo $this->get_field_name( 'person_email' ) . '[]'; ?>" type="text"  placeholder="Email"/></p>
         </div>
     </script>
 
@@ -123,7 +123,7 @@ class UW_Widget_Contact extends WP_Widget
     $instance['person_phone'] = $new_instance['person_phone'];
 		$instance['person_email'] = $new_instance['person_email'];
     return $instance;
-  
+
   }
 
   function widget($args, $instance)
@@ -138,7 +138,7 @@ class UW_Widget_Contact extends WP_Widget
     ?>
 
     <?php  echo $before_widget; ?>
-    
+
     <div class="contact-widget-inner">
       <span>
 
@@ -148,7 +148,7 @@ class UW_Widget_Contact extends WP_Widget
 
       </span>
 
-   <?php 
+   <?php
 
     if (isset($instance['person_name'])) {
 
@@ -156,7 +156,7 @@ class UW_Widget_Contact extends WP_Widget
 
       if(is_array($remake_form_person)){
 
-        foreach ($remake_form_person as $key => $values) {   
+        foreach ($remake_form_person as $key => $values) {
 
             echo '<h3 class=\'person-name\'>' . $instance['person_name'][$key] . '</h3>';
             echo '<p class=\'person-title\'>' . $instance['person_title'][$key] . '</p>';


### PR DESCRIPTION
Bug fix for issue #52. This should be backwards compatible. 
For future widget development, we should keep in mind that Wordpress's default is to enable the save button only when a form in the widget menu is changed, not when it is deleted entirely. 
In this case, the form wasn't saving to the database when a contact was removed because the contact form was being removed, not updated/changed. For this fix, I triggered the save button automatically once the remove button was clicked so that its original functionality was maintained.