### PR TITLE
feature: added user-editable thinstrip menu

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -56,6 +56,23 @@ if ( ! function_exists( 'uw_dropdowns') ) :
   }
 endif;
 
+if ( ! function_exists( 'uw_thinstrip') ) :
+  function uw_thinstrip()
+  {
+
+    echo '<nav class="uw-thin-strip-nav" aria-label="role navigation">';
+
+    echo  wp_nav_menu( array(
+        'theme_location'  => 'thin-strip',
+        'container'       => false,
+        'items_wrap'      => '<ul class="uw-thin-links">%3$s</ul>',
+        'depth'           => 1,
+      ) );
+
+    echo '</nav>';
+  }
+endif;
+
 if ( ! function_exists('uw_sidebar_menu') ) :
 
   function uw_sidebar_menu()

--- a/setup/class.uw-thin-strip-menu.php
+++ b/setup/class.uw-thin-strip-menu.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * UW thin strip menu
+ * This installs the default dropdowns for the UW thin strip
+ */
+
+class UW_Thin_Strip_Menu
+{
+
+    const NAME           = 'Thin Strip Menu';
+    const LOCATION       = 'thin-strip';
+    const DISPLAY_NAME   = 'Thin Strip Menu';
+    const DEFAULT_STATUS = 'publish';
+
+    function __construct()
+    {
+        $this->menu_items = array();
+        add_action( 'after_setup_theme', array( $this, 'register_thin_strip_menu') );
+        add_action( 'after_setup_theme', array( $this, 'install_default_thin_strip_menu') );
+        add_action( 'wp_update_nav_menu', array( $this, 'save_thin_strip') );
+    }
+
+    function register_thin_strip_menu()
+    {
+        register_nav_menu( self::LOCATION, __( self::NAME ) );
+    }
+
+    function install_default_thin_strip_menu()
+    {
+
+        $this->generate_menu_list();
+        $this->MENU_ID = wp_create_nav_menu( self::DISPLAY_NAME );
+
+        // wp_create_nav_menu returns a WP_Error if the menu already exists;
+        if ( is_wp_error( $this->MENU_ID ) ) return;
+
+
+        //      Each site in the network will have a different menu item ID for each thing.  Make the first menu and save its id
+        //      then set that ID as the menu-item-parent-id for each child.  Then save each child.
+        foreach ( $this->menu_items as $menu_name => $menu_attributes ) {
+
+            $children = $menu_attributes['children'];
+
+            unset( $menu_attributes['children'] );
+
+
+            $parent_id = wp_update_nav_menu_item( $this->MENU_ID, $menu_item_db_id=0, $menu_attributes );
+
+            if ( $children )
+            {
+                foreach ( $children as $submenu){
+                    $submenu['menu-item-parent-id'] = $parent_id;
+                    wp_update_nav_menu_item($this->MENU_ID, $menu_item_db_id=0, $submenu);
+                }
+            }
+        }
+
+        $this->set_uw_menu_location();
+    }
+
+    function set_uw_menu_location()
+    {
+        $locations = (ARRAY) get_theme_mod( 'nav_menu_locations' );
+        $locations[ 'thin-strip' ] = $this->MENU_ID;
+        set_theme_mod( 'nav_menu_locations', $locations );
+    }
+
+     function generate_menu_list()
+     {
+
+        // The default About dropdown.
+        $this->add_menu_item( 'Students', 'http://uw.edu/studentlife' );
+
+
+        // The default Academics dropdown.
+        $this->add_menu_item( 'Parents', 'http://uw.edu/parents' );
+
+
+        // the default Admissions dropdown.
+        $this->add_menu_item( 'Faculty & Staff', 'http://uw.edu/facultystaff' );
+
+
+        // The default News dropdown.
+        $this->add_menu_item( 'Alumni', 'http://uw.edu/alumni' );
+
+
+    }
+
+    function add_menu_item( $name, $url, $parent=null )
+    {
+        $item['menu-item-title']    = $name;
+        $item['menu-item-url']      = $url;
+        $item['menu-item-status'] = self::DEFAULT_STATUS;
+
+
+        if ( $parent )
+            $this->menu_items[ $parent ]['children'][$name] = $item;
+        else
+            $this->menu_items[$name] = $item;
+
+    }
+
+    function save_thin_strip($menu_id){
+        $menu_object = wp_get_nav_menu_object( $menu_id );
+        if($menu_object->slug === 'thin-strip'){
+            if (!current_user_can('Super Admin')){
+                wp_die('Insufficient permission: can not edit the default dropdowns menu.');
+            }
+        }
+    }
+
+}

--- a/setup/class.uw-thin-strip-menu.php
+++ b/setup/class.uw-thin-strip-menu.php
@@ -40,20 +40,20 @@ class UW_Thin_Strip_Menu
         //      then set that ID as the menu-item-parent-id for each child.  Then save each child.
         foreach ( $this->menu_items as $menu_name => $menu_attributes ) {
 
-            $children = $menu_attributes['children'];
+            // $children = $menu_attributes['children'];
 
             unset( $menu_attributes['children'] );
 
 
             $parent_id = wp_update_nav_menu_item( $this->MENU_ID, $menu_item_db_id=0, $menu_attributes );
 
-            if ( $children )
-            {
-                foreach ( $children as $submenu){
-                    $submenu['menu-item-parent-id'] = $parent_id;
-                    wp_update_nav_menu_item($this->MENU_ID, $menu_item_db_id=0, $submenu);
-                }
-            }
+            // if ( $children )
+            // {
+            //     foreach ( $children as $submenu){
+            //         $submenu['menu-item-parent-id'] = $parent_id;
+            //         wp_update_nav_menu_item($this->MENU_ID, $menu_item_db_id=0, $submenu);
+            //     }
+            // }
         }
 
         $this->set_uw_menu_location();
@@ -91,7 +91,7 @@ class UW_Thin_Strip_Menu
     {
         $item['menu-item-title']    = $name;
         $item['menu-item-url']      = $url;
-        $item['menu-item-status'] = self::DEFAULT_STATUS;
+        $item['menu-item-status']   = self::DEFAULT_STATUS;
 
 
         if ( $parent )

--- a/setup/class.uw.php
+++ b/setup/class.uw.php
@@ -22,6 +22,7 @@ class UW
         require_once($parent . 'class.uw-scripts.php');
         require_once($parent . 'class.uw-styles.php');
         require_once($parent . 'class.uw-dropdowns.php');
+        require_once($parent . 'class.uw-thin-strip-menu.php'); //library thinstrip
         require_once($parent . 'class.images.php');
         require_once($parent . 'class.squish_bugs.php');
         require_once($parent . 'class.filters.php');
@@ -67,6 +68,7 @@ class UW
         $this->Users             = new UW_Users;
         $this->SidebarMenuWalker = new UW_Sidebar_Menu_Walker;
         $this->Dropdowns         = new UW_Dropdowns;
+        $this->ThinStripMenu     = new UW_Thin_Strip_Menu; //thinstripmenu
         $this->Quicklinks        = new UW_QuickLinks;
         $this->Shortcodes        = new UW_Shortcodes;
         $this->MediaCredit       = new UW_Media_Credit;
@@ -81,4 +83,3 @@ class UW
         $this->Settings          = new UW_Settings;
     }
 }
- 

--- a/thinstrip.php
+++ b/thinstrip.php
@@ -5,14 +5,21 @@
     <a href="http://uw.edu" title="University of Washington Home" class="uw-wordmark" tabindex='-1' aria-hidden='true'>University of Washington</a>
   </div>
   <div class='align-right'>
-      <nav class="uw-thin-strip-nav" aria-label='role navigation'>
+      <!-- static thinstip nav links -->
+      <!-- <nav class="uw-thin-strip-nav" aria-label='role navigation'>
           <ul class="uw-thin-links">
             <li><a href="http://uw.edu/studentlife" title="Students">Students</a></li>
             <li><a href="http://uw.edu/parents" title="Parents">Parents</a></li>
             <li><a href="http://uw.edu/facultystaff" title="Faculty & Staff">Faculty & Staff</a></li>
             <li><a href="http://uw.edu/alumni" title="Alumni">Alumni</a></li>
           </ul>
+      </nav> -->
+
+      <!--Wordpress menu generated links -->
+      <nav class="uw-thin-strip-nav" aria-label='role navigation'>
+        <?php wp_nav_menu( array( 'theme_location' => 'thin-strip','container' => false,'items_wrap' => '<ul class="uw-thin-links">%3$s</ul>', ) ); ?>
       </nav>
+
       <nav id='search-quicklinks' aria-label='search and quick links'>
       <button class='uw-search' aria-owns='uwsearcharea' aria-controls='uwsearcharea' aria-expanded='false' aria-label='open search area' aria-haspopup='true'>
 <!--[if gt IE 8]><!-->

--- a/thinstrip.php
+++ b/thinstrip.php
@@ -16,9 +16,10 @@
       </nav> -->
 
       <!--Wordpress menu generated links -->
-      <nav class="uw-thin-strip-nav" aria-label='role navigation'>
-        <?php wp_nav_menu( array( 'theme_location' => 'thin-strip','container' => false,'items_wrap' => '<ul class="uw-thin-links">%3$s</ul>', ) ); ?>
-      </nav>
+      <!-- <nav class="uw-thin-strip-nav" aria-label='role navigation'>
+        <?php //wp_nav_menu( array( 'theme_location' => 'thin-strip','container' => false,'items_wrap' => '<ul class="uw-thin-links">%3$s</ul>', ) ); ?>
+      </nav> -->
+      <? uw_thinstrip(); ?>
 
       <nav id='search-quicklinks' aria-label='search and quick links'>
       <button class='uw-search' aria-owns='uwsearcharea' aria-controls='uwsearcharea' aria-expanded='false' aria-label='open search area' aria-haspopup='true'>


### PR DESCRIPTION
# User Editable Thin Strip Menu
Allows content creators to change the menu items and link in the Thin Strip at the top through the Wordpress UI. 

## File changes 

``` class.uw.thin-strip-menu.php ``` is a new class that is similar to the white dropdown menu class and does the heavy lifting of adding the menu to the wordpress UI, registering it, and setting defaults. 

``` thinstrip.php ``` has the flat HTML links commented out and the new wordpress menu php added

``` class.uw.php ``` is edited to require and initialize the new menu php
