### PR TITLE
bugfix: used caption shortcode in place of mediacredit

### DIFF
--- a/setup/class.uw-media-caption.php
+++ b/setup/class.uw-media-caption.php
@@ -10,7 +10,7 @@ class UW_Media_Caption
   function UW_Media_Caption()
   {
     add_filter( 'img_caption_shortcode', array( $this, 'add_media_credit_to_caption_shortcode_filter'), 10, 3 );
-  
+
   }
 
   //
@@ -29,7 +29,8 @@ class UW_Media_Caption
     ), $attr));
 
 
-    if ( 1 > (int) $width || empty($caption) )
+    // if ( 1 > (int) $width || empty($caption) )
+    if ( 1 > (int) $width )
       return $content;
 
     if ( $id ) $id = 'id="' . esc_attr($id) . '" ';
@@ -38,7 +39,7 @@ class UW_Media_Caption
     if ( $match[0] ) $credit = get_post_meta($match[0], '_media_credit', true);
     if ( $match[0] ) $source_url = get_post_meta( $match[0], "_source_url", true );
     if ( $credit ) $credit = '<span class="wp-media-credit">'. $credit . '</span>';
-  
+
   // $credit = '<a href="'. ($source_url) .'">'. $credit .'</a>';
 
     if ($source_url != '') {
@@ -46,7 +47,7 @@ class UW_Media_Caption
     }else {
       $credit = ($source_url) . $credit ;
     }
-   
+
    // Extract attachment $post->ID
 
     return '<div ' . $id . 'class="wp-caption ' . esc_attr($align) . '" style="width: ' . (10 + (int) $width) . 'px">'
@@ -59,9 +60,9 @@ class UW_Media_Caption
 
 
 
-  
 
-  
+
+
 
 
 

--- a/setup/class.uw-media-credit.php
+++ b/setup/class.uw-media-credit.php
@@ -37,12 +37,11 @@ class UW_Media_Credit
 
     $credit = get_post_meta( $id, '_media_credit', true);
     $img    = wp_get_attachment_image_src( $id, $size );
+    $width = $img[1];
+    $height = $img[2];
 
     return $credit ?
-      "<dl class='mediacredit align$align' data-credit='$credit' data-align='align$align' data-size='$size' style='width:{$img[1]}px'>
-        <dt class='mediacredit-dt'>$html</dt>
-        <dd class='wp-caption-dd'>$credit</dd>
-      </dl>" : $html;
+      '[caption id="attachment_' . $id . '" align="' . $align . '" width="' . $width . '" credit="' . $credit . '"]<a href="' . $url . '"><img src="' . $url . '" alt="' . $caption . '" width="' . $width . '" height="' . $height . '" class="size-full wp-image-' . $id . '" /></a> ' . $caption . '[/caption]' : $html;
   }
 
   /**


### PR DESCRIPTION
When a media credit is added to an image and no caption text, the Add Media button attempts to use `[mediacredit]` shortcode to generate the output. This shortcode and the WordPress admin ajax functionality is broken and results in the image not appearing on the post page.

This fix bypasses use of the `[mediacredit]` shortcode and replaces it with `[caption]` as a stopgap solution.

In the future, we should adjust the Add Media ajax to process the media credit fields along with the caption and merge the code together since they work hand-in-hand.