### PR TITLE
Type check to supress warnings for strpos

### DIFF
--- a/setup/class.googleapps.php
+++ b/setup/class.googleapps.php
@@ -32,6 +32,11 @@ class UW_GoogleApps
 
   function uw_google_calendar_embed_to_shortcode( $content )
   {
+
+    if ( !is_string($content) )
+      return $content;
+    
+
     if ( false === strpos( $content, '<iframe ' ) && false === strpos( $content, 'google.com/calendar' ) )
       return $content;
 


### PR DESCRIPTION
Noting a warning in development.  `strpos` demands a string, and I am assuming your process also wants one too?
