### PR TITLE
Fix issue with subpage list shortcode defaulting to grid view

### DIFF
--- a/setup/class.subpage-list-shortcode.php
+++ b/setup/class.subpage-list-shortcode.php
@@ -24,7 +24,7 @@ class UW_SubpageList
     {
         $attributes = (object) shortcode_atts( array(
             'link'    => 'Read more',
-            'tilebox' => false
+            'tilebox' => 'false'
         ), $atts );
 
         global $post;
@@ -38,7 +38,7 @@ class UW_SubpageList
 
             $permalink = get_post_permalink($page->ID);
 
-            if (!$attributes->tilebox){
+            if ($attributes->tilebox === 'false'){
               $output = $output . sprintf("<h2><a href='%s'>%s</a></h2>", $permalink, $page->post_title);
               if (get_option('show_byline_on_posts')){
                 $output = $output . sprintf("<div class='author-info'><p class='author-desc'><small>%s</small></p></div>", get_the_author_meta('display_name', $page->post_author));


### PR DESCRIPTION
Edited `setup/class.subpage-list-shortcode.php`  to fix the issue with the subpage list shortcode  displaying the grid view regardless of whether the grid view or list view is specified.