### PR TITLE
Fix Child/Parent Version Style Issue

### DIFF
--- a/setup/class.uw-styles.php
+++ b/setup/class.uw-styles.php
@@ -13,7 +13,9 @@ class UW_Styles
 
   function __construct()
   {
-    $version = is_child_theme() ? wp_get_theme('uw-2014')->get('Version') : wp_get_theme()->get('Version');
+    $child_version = is_child_theme() ? wp_get_theme()->get('Version')  : wp_get_theme('uw-2014')->get('Version');
+    $parent_version = wp_get_theme('uw-2014')->get('Version');
+
 
     $this->STYLES = array(
 
@@ -29,14 +31,14 @@ class UW_Styles
         'id'      => 'uw-master',
         'url'     => get_bloginfo( 'template_url' ) . '/style' . $this->dev_stylesheet() . '.css',
         'deps'    => array(),
-        'version' => $version
+        'version' => $parent_version
       ),
 
       'uw-style' => array (
           'id'      => 'uw-style',
           'url'     => get_bloginfo('stylesheet_url'),
           'deps'    => array('uw-master'),
-          'version' => $version,
+          'version' => $child_version,
           'child'   => true
       ),
 


### PR DESCRIPTION
Submitting as I can't clear my cache again.  The semver number for uw-2014 is being appended to my .css file.

1) The original ternary operator had its true/false order reversed.  If 'get_child_theme' returns true, you should hopefully get (for compatible child themes' versions, not the version for uw-2014

2) If this request is accepted, the uw-2014 stylesheet pulls the semver from your stylesheet, and child themes' get their versions from their themes themselves.

I wonder if we want a deeper check to see not just if the child theme is present, but if present AND has a version?  That's also easy to add, but this works for now at least.
