### PR TITLE
Fix for child & parent theme style and script versions

### DIFF
--- a/setup/class.uw-scripts.php
+++ b/setup/class.uw-scripts.php
@@ -16,6 +16,9 @@ class UW_Scripts
 
     $multi = is_multisite();
 
+    $parent = get_template();
+    $parent_version = wp_get_theme($parent)->get('Version');
+
     $this->SCRIPTS = array_merge( array(
 
       'jquery' => array (
@@ -30,7 +33,7 @@ class UW_Scripts
         'id'        => 'site',
         'url'       => get_bloginfo('template_directory') . '/js/site' . $this->dev_script() . '.js',
         'deps'      => array( 'backbone' ),
-        'version'   => wp_get_theme()->get('Version'),
+        'version'   => $parent_version,
         'admin'     => false,
         'style_dir' => site_url()
         // 'variables' => array( 'is_multisite' =>  $multi ),
@@ -40,7 +43,7 @@ class UW_Scripts
         'id'      => 'wp.admin',
         'url'     => get_bloginfo('template_directory') . '/assets/admin/js/admin.js',
         'deps'    => array( 'jquery' ),
-        'version' => wp_get_theme()->get('Version'),
+        'version' => $parent_version,
         'admin'   => true
       ),
 

--- a/setup/class.uw-styles.php
+++ b/setup/class.uw-styles.php
@@ -13,7 +13,11 @@ class UW_Styles
 
   function __construct()
   {
-    $version = is_child_theme() ? wp_get_theme('uw-2014')->get('Version') : wp_get_theme()->get('Version');
+
+    $parent = get_template();
+    $child = get_stylesheet();
+    $parent_version = wp_get_theme($parent)->get('Version');
+    $child_version = wp_get_theme($child)->get('Version');
 
     $this->STYLES = array(
 
@@ -29,14 +33,14 @@ class UW_Styles
         'id'      => 'uw-master',
         'url'     => get_bloginfo( 'template_url' ) . '/style' . $this->dev_stylesheet() . '.css',
         'deps'    => array(),
-        'version' => $version
+        'version' => $parent_version
       ),
 
       'uw-style' => array (
           'id'      => 'uw-style',
           'url'     => get_bloginfo('stylesheet_url'),
           'deps'    => array('uw-master'),
-          'version' => $version,
+          'version' => $child_version,
           'child'   => true
       ),
 


### PR DESCRIPTION
Follow-up to #157 
- Added check for child style versions
- Included default script versions as well (child theme scripts not impacted)
- Simplified checks for parent and child versions
- Will work in instance where uw-2014 is not the folder name