### PR TITLE
Don't transform non-calendar embeds into calendar shortcodes

### DIFF
--- a/setup/class.googleapps.php
+++ b/setup/class.googleapps.php
@@ -37,7 +37,7 @@ class UW_GoogleApps
       return $content;
     
 
-    if ( false === strpos( $content, '<iframe ' ) && false === strpos( $content, 'google.com/calendar' ) )
+    if ( false === strpos( $content, '<iframe ' ) || false === strpos( $content, 'google.com/calendar' ) )
       return $content;
 
 


### PR DESCRIPTION
The uw_google_calendar_embed_to_shortcode() function is supposed to convert a google calendar iframe into a shortcode, but it actually attempts to transform any content that contains either an iframe tag or a link to google.com/calendar.

The regex will succeed on any google url, so for example this map embed: 
`<iframe src="https://www.google.com/maps/d/embed?mid=1k7y_cvcBbZQlqZ-mTiz1JpFQ53J9cyCk" width="640" height="480"></iframe>`

gets transformed into 

`[googleapps domain="www" dir="calendar/embed" query="mid=1k7y_cvcBbZQlqZ-mTiz1JpFQ53J9cyCk" width="630" height="480"]`

which doesn't work.

This should correct it.