### PR TITLE
suppresses admin bar for non-super admin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -26,3 +26,10 @@ if (!function_exists('setup_uw_object')){
 
 $UW = setup_uw_object();
 
+// suppresses admin bar for non-super admin
+add_action('after_setup_theme', 'remove_admin_bar');
+function remove_admin_bar() {
+  if (!current_user_can('administrator') && !is_admin()) {
+    show_admin_bar(false);
+  }
+}


### PR DESCRIPTION
Hi uw web team,

When I filled in the information on the following page today, I found WordPress admin bar at the top of the page.
[https://registrar.washington.edu/diploma-name/?](https://registrar.washington.edu/diploma-name/?)
I suggest adding the function of hiding the admin bar